### PR TITLE
Allow specifying service name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.ncrunch*
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/FakeHttpService.Tests/Given_I_want_to_get_fake_responses_in_a_test.cs
+++ b/FakeHttpService.Tests/Given_I_want_to_get_fake_responses_in_a_test.cs
@@ -64,19 +64,27 @@ namespace FakeHttpService.Tests
         [Fact]
         public async Task When_an_expected_request_is_not_made_but_FakeServer_is_configured_to_throw_Then_an_exception_is_thrown()
         {
+            Uri address = null;
+
             Action createServiceWithoutInvoking = () =>
             {
-                using (new FakeHttpService(throwOnUnusedHandlers: true)
+                using (var fakeService = new FakeHttpService(
+                    "my service", 
+                    throwOnUnusedHandlers: true)
                     .OnRequest(r => r.Path == "foo")
-                    .RespondWith(async r =>
-                    {
-                    }))
+                    .RespondWith(async r => { }))
                 {
+                    address = fakeService.BaseAddress;
                 }
             };
 
-            createServiceWithoutInvoking.ShouldThrow<InvalidOperationException>(
-                "Because failing to perform a request can be an error");
+            createServiceWithoutInvoking
+                .ShouldThrow<InvalidOperationException>(
+                "Because failing to perform a request can be an error")
+                .Which
+                .Message
+                .Should()
+                .StartWith( $"{nameof(FakeHttpService)} \"my service\" @ {address} expected requests");
         }
 
         [Fact]

--- a/FakeHttpService/FakeHttpService.cs
+++ b/FakeHttpService/FakeHttpService.cs
@@ -14,7 +14,6 @@ namespace FakeHttpService
 {
     public class FakeHttpService : IDisposable
     {
-        private Uri _baseAddress;
         private readonly bool serviceIdIsUserSpecified;
         private readonly IWebHost _host;
 
@@ -100,20 +99,7 @@ namespace FakeHttpService
             }
         }
 
-        public Uri BaseAddress
-        {
-            get => _baseAddress;
-
-            set
-            {
-                if (_baseAddress != null)
-                {
-                    throw new Exception("Base Address already set");
-                }
-
-                _baseAddress = value;
-            }
-        }
+        public Uri BaseAddress { get; }
 
         public string ServiceId { get; }
 


### PR DESCRIPTION
This makes error messages clearer, especially when using multiple instances of `FakeHttpService` at the same time.