### PR TITLE
make PocketLogger a private dependency

### DIFF
--- a/FakeHttpService/FakeHttpService.csproj
+++ b/FakeHttpService/FakeHttpService.csproj
@@ -8,6 +8,8 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="PocketLogger" Version="0.2.2" />
+    <PackageReference Include="PocketLogger" Version="0.2.2">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The PocketLogger dependency was previously public, meaning that when pulling in FakeHttpServer, you would also pull in PocketLogger, which is not the intention. This also led to package downgrade warnings which should not be applicable.